### PR TITLE
bump podspec version to 4.0.1

### DIFF
--- a/SwiftKVC.podspec
+++ b/SwiftKVC.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "SwiftKVC"
-    s.version      = "4.0.0"
+    s.version      = "4.0.1"
     s.summary      = "Key-Value Coding (KVC) for native Swift classes and structs"
     s.description  = <<-DESC
                         SwiftKVC enables Key-Value Coding (KVC) for native Swift classes and structs.
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
     s.homepage     = "https://github.com/bradhilton/SwiftKVC"
     s.license      = { :type => "MIT", :file => "LICENSE" }
     s.author       = { "Brad Hilton" => "brad@skyvive.com" }
-    s.source       = { :git => "https://github.com/bradhilton/SwiftKVC.git", :tag => "4.0.0" }
+    s.source       = { :git => "https://github.com/bradhilton/SwiftKVC.git", :tag => "4.0.1" }
     s.ios.deployment_target = "8.0"
     s.osx.deployment_target = "10.9"
     s.source_files  = "SwiftKVC", "SwiftKVC/**/*.{swift,h,m}"


### PR DESCRIPTION
Hi, thanks for merging #8.
I forgot to bump the version of SwiftKVC itself, so that `pod update` would work -- adding this now.
Would you follow with tagging?

```
git tag 4.0.1
git push --tags
pod trunk push
```

Thanks in advance!